### PR TITLE
Allows you to remove the minecraft-data at compile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ thiserror = "1.0.31"
 serde_json = "1.0.81"
 serde_derive = "1.0.137"
 serde = "1.0.137"
-include_dir = "0.7.2"
-itertools = "0.10.3"
-lazy_static = "1.4.0"
+include_dir = { version = "0.7.2", optional = true }
+itertools = { version = "0.10.3", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
+
+[features]
+default = ["include_data"]
+include_data = ["include_dir", "itertools", "lazy_static"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ itertools = { version = "0.10.3", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 
 [features]
-default = ["include_data"]
-include_data = ["include_dir", "itertools", "lazy_static"]
+default = ["include-data"]
+include-data = ["include_dir", "itertools", "lazy_static"]
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This repository is a rust library to access minecraft data.
 The data itself hosted in the [minecraft-data](https://github.com/PrismarineJS/minecraft-data) repository
 and included into the library at compile time.
 
+
+### Excluding the minecraft-data at compile time
+By adding `default-features=false` to the dependency in your `Cargo.toml` file, you can exclude the minecraft-data from the library.
+
+
 ## Usage
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,15 @@
 extern crate serde_derive;
 
 /// Provides data access methods
-#[cfg(feature="include_data")]
+#[cfg(feature="include-data")]
 pub mod api;
-#[cfg(feature="include_data")]
+#[cfg(feature="include-data")]
 pub(crate) mod data;
 /// Contains the type definitions for the data
 pub mod models;
 pub(crate) mod utils;
 
-#[cfg(feature="include_data")]
+#[cfg(feature="include-data")]
 pub use api::Api;
 pub use utils::error::DataError;
 pub use utils::error::DataResult;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,15 @@
 extern crate serde_derive;
 
 /// Provides data access methods
+#[cfg(feature="include_data")]
 pub mod api;
+#[cfg(feature="include_data")]
 pub(crate) mod data;
 /// Contains the type definitions for the data
 pub mod models;
 pub(crate) mod utils;
 
+#[cfg(feature="include_data")]
 pub use api::Api;
 pub use utils::error::DataError;
 pub use utils::error::DataResult;


### PR DESCRIPTION
I really don't want the data all being included at compile time. (Also try to stay away from lazy static personally)

This change will not break anything for anyone. But allows me to exclude the data from being included. I just want the models