### PR TITLE
Rename harvest_tool to harvest_tools

### DIFF
--- a/src/models/block.rs
+++ b/src/models/block.rs
@@ -11,7 +11,7 @@ pub struct Block {
     pub diggable: bool,
     pub bounding_box: BoundingBox,
     pub material: Option<String>,
-    pub harvest_tool: Option<HashMap<u32, bool>>,
+    pub harvest_tools: Option<HashMap<u32, bool>>,
     pub variations: Option<Vec<Variation>>,
     pub drops: Vec<u32>,
     pub transparent: bool,


### PR DESCRIPTION
I noticed that this field is always empty at the moment. Looking into it a bit more, it seems like the field name should be `harvest_tools` rather than `harvest_tool`. I've tested this to verify the correct data is being loaded now.