### PR TITLE
fallback to major version

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -68,6 +68,12 @@ pub fn get_path(version: &Version, filename: &str) -> DataResult<String> {
     PATHS
         .pc
         .get(&version.minecraft_version)
+        // fallback to major version
+        .or_else(||
+            PATHS
+            .pc
+            .get(&version.major_version)
+        )
         .ok_or_else(|| DataError::NotFoundError(version.minecraft_version.clone()))?
         .get(filename)
         .cloned()


### PR DESCRIPTION
Minor versions will fallback to their major version if they haven't been explicitly defined in `dataPaths.json`, assuming no changes in their data.
E.g. If the version is 1.8.9, data paths for 1.8 will be used instead of raising an Err.