### PR TITLE
fix: include all state ids

### DIFF
--- a/src/api/blocks.rs
+++ b/src/api/blocks.rs
@@ -30,7 +30,7 @@ impl Blocks {
         blocks.iter().for_each(|b| {
             let min_state_id = b.min_state_id.unwrap_or(b.id << 4);
             let max_state_id = b.max_state_id.unwrap_or(min_state_id + 15);
-            (min_state_id..max_state_id).for_each(|s| {
+            (min_state_id..=max_state_id).for_each(|s| {
                 blocks_map.insert(s, b.clone());
             });
         });


### PR DESCRIPTION
loop doesn't include max_state_id because the upperbound is exclusive
loop also doesn't work where min_state_id = max_state_id because that is skipped intirely 